### PR TITLE
Add support for adoc and ad extensions

### DIFF
--- a/notepad++/userDefineLang.xml
+++ b/notepad++/userDefineLang.xml
@@ -1,5 +1,5 @@
 <NotepadPlus>
-    <UserLang name="Asciidoc" ext="asc asciidoc txt" udlVersion="2.1">
+    <UserLang name="Asciidoc" ext="asc asciidoc txt adoc ad" udlVersion="2.1">
         <Settings>
             <Global caseIgnored="no" allowFoldOfComments="no" foldCompact="no" forcePureLC="1" decimalSeparator="0" />
             <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />


### PR DESCRIPTION
.adoc and .ad have become common AsciiDoc file extensions. For example they are supported by Sublime, github, AsciiDoctor Live Preview and the referenced in the AsciiDoctor Writers Guide, etc.

https://github.com/SublimeText/AsciiDoc/pull/4
https://github.com/github/markup/pull/88
https://github.com/asciidoctor/asciidoctor-chrome-extension/blob/master/README.adoc
http://asciidoctor.org/docs/asciidoc-writers-guide/
