### PR TITLE
Fix highlighting when page break syntax is used

### DIFF
--- a/notepad++/userDefineLang.xml
+++ b/notepad++/userDefineLang.xml
@@ -32,7 +32,7 @@
             <Keywords name="Keywords6"></Keywords>
             <Keywords name="Keywords7"></Keywords>
             <Keywords name="Keywords8"></Keywords>
-            <Keywords name="Delimiters">00&quot; 01 02&quot; 03[ 04 05] 06` 07 08` 09` 10 11&apos; 12_ 13 14_ 15 16 17 18&lt;&lt; 19 20&gt;&gt; 21 22 23</Keywords>
+            <Keywords name="Delimiters">00&quot; 01 02&quot; 03[ 04 05] 06` 07 08` 09` 10 11&apos; 12_ 13 14_ 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>
         <Styles>
             <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />


### PR DESCRIPTION
When page breaks are used (e.g. "<<<") the remainder of the document
was turning yellow. It seems the page break syntax was triggering the syntax for internal links (e.g. "<<Jump Here>>").

This change removes the internal link styling aka 'Delimiter 7 style'.

Unless there's a smarter fix, I feel it's more important that the whole document _not_ be yellow than having internal links that _are_ yellow.
