### PR TITLE
Correct single line comment syntax for Notepad++

### DIFF
--- a/notepad++/userDefineLang.xml
+++ b/notepad++/userDefineLang.xml
@@ -5,7 +5,7 @@
             <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
         </Settings>
         <KeywordLists>
-            <Keywords name="Comments">00. 01 02 03//// 04////</Keywords>
+            <Keywords name="Comments">00// 01 02 03//// 04////</Keywords>
             <Keywords name="Numbers, prefix1"></Keywords>
             <Keywords name="Numbers, prefix2"></Keywords>
             <Keywords name="Numbers, extras1"></Keywords>


### PR DESCRIPTION
Single line comment in asciidoc is `//`, but it was set to `.`