### PR TITLE
Ifeval definition

### DIFF
--- a/gedit/asciidoc.lang
+++ b/gedit/asciidoc.lang
@@ -63,9 +63,9 @@
         <match>\+\s*$</match>
     </context>
 
-    <define-regex id="macro-names">image|include|sys|sys2|eval</define-regex>
-    <define-regex id="inline-macro-names">pass|latexmath|asciimath|indexterm|indexterm2|footnote|footnoteref</define-regex>
-    <define-regex id="preproc-names">ifdef|ifndef|endif|unfloat|template</define-regex>
+    <define-regex id="macro-names">\b(image|include|sys|sys2|eval)\b</define-regex>
+    <define-regex id="inline-macro-names">\b(pass|latexmath|asciimath|indexterm|indexterm2|footnote|footnoteref)\b</define-regex>
+    <define-regex id="preproc-names">\b(ifdef|ifndef|ifeval|endif|unfloat|template)\b</define-regex>
 
     <!-- TITLES -->
     <context id="title">
@@ -268,7 +268,7 @@
         <start>^(\%{macro-names})::[^\s\[\]]*\[</start>
         <end>\]$</end>
     </context>
-    
+
     <context id="blockPreproc" end-at-line-end="true" style-ref="preprocessor">
         <start>^(\%{preproc-names})::[^\s\[\]]*\[</start>
         <end>\]$</end>

--- a/test/issues/13.adoc
+++ b/test/issues/13.adoc
@@ -1,0 +1,25 @@
+:city: Munich
+//:city: Dneprpetrovsk
+
+= Ifdef and Ifeval Example
+
+ifdef::city[]
+This is the {city} Travel Guide.
+endif::[]
+ifndef::city[]
+This is probably not a real Travel Guide. Don't trust it.
+endif::[]
+
+ifdef::revnumber[This is version {revnumber} of the {city} Travel Guide.]
+
+== Visits to {city}
+
+Visiting {city} is a fantastic idea, whatever time of year it may be.
+
+ifeval::["{city}" == "Munich"]
+However, the best time to visit {city} is during the end of September, when
+the city is taken over by drunk tourists.
+endif::[]
+ifeval::["{city}" == "Dneprpetrovsk"]
+However, the best time to visit {city} is in January when it is coldest.
+endif::[]


### PR DESCRIPTION
* Highlight `ifeval::[...]` properly
* Make sure not to randomly highlight keywords like `eval` etc. in the text by adding `\b` (not sure whether `^` would be necessary  as well